### PR TITLE
fix(typography): accept null and short-circuit to '' (BC restore)

### DIFF
--- a/src/TypographyExtension.php
+++ b/src/TypographyExtension.php
@@ -51,7 +51,7 @@ final class TypographyExtension extends AbstractExtension
     /**
      * Apply PHP-Typography to a string.
      *
-     * @param string|\Stringable|null $string       Plain string, any Stringable (Twig\Markup from `|raw`-wrapped HTML, value objects with __toString, …), or null. Null short-circuits to '' so optional/unfilled template fields (`{{ content.button.title|typography }}` against an empty ACF link) don't fatal under strict types — matches the null-tolerance convention of built-in Twig filters like `|trim`, `|lower`, `|escape`. Cast happens at entry so the rest of the method works on a plain string.
+     * @param string|\Stringable|null $string       Plain string, any Stringable (Twig\Markup from `|raw`-wrapped HTML, value objects with __toString, …), or null. Null short-circuits to '' so optional/unfilled template fields (`{{ content.button.title|typography }}` against an empty ACF link) don't fatal under strict types — matches the null-tolerance convention of built-in Twig filters like `|trim`, `|lower`, `|escape`. For non-null inputs, the cast happens at entry so the rest of the method works on a plain string.
      * @param array<string, mixed>    $arguments    Per-call setting overrides; merged on top of constructor defaults.
      * @param bool                    $use_defaults Initialise PHP-Typography's own sane defaults before applying ours.
      */

--- a/src/TypographyExtension.php
+++ b/src/TypographyExtension.php
@@ -51,12 +51,16 @@ final class TypographyExtension extends AbstractExtension
     /**
      * Apply PHP-Typography to a string.
      *
-     * @param string|\Stringable    $string        Plain string or any Stringable (Twig\Markup from `|raw`-wrapped HTML, value objects with __toString, …). Cast happens at entry so the rest of the method works on a plain string.
-     * @param array<string, mixed>  $arguments     Per-call setting overrides; merged on top of constructor defaults.
-     * @param bool                  $use_defaults  Initialise PHP-Typography's own sane defaults before applying ours.
+     * @param string|\Stringable|null $string       Plain string, any Stringable (Twig\Markup from `|raw`-wrapped HTML, value objects with __toString, …), or null. Null short-circuits to '' so optional/unfilled template fields (`{{ content.button.title|typography }}` against an empty ACF link) don't fatal under strict types — matches the null-tolerance convention of built-in Twig filters like `|trim`, `|lower`, `|escape`. Cast happens at entry so the rest of the method works on a plain string.
+     * @param array<string, mixed>    $arguments    Per-call setting overrides; merged on top of constructor defaults.
+     * @param bool                    $use_defaults Initialise PHP-Typography's own sane defaults before applying ours.
      */
-    public function applyTypography(string|\Stringable $string, array $arguments = [], bool $use_defaults = true): string
+    public function applyTypography(string|\Stringable|null $string, array $arguments = [], bool $use_defaults = true): string
     {
+        if ($string === null) {
+            return '';
+        }
+
         $string = (string) $string;
 
         $settings = new Settings($use_defaults);

--- a/tests/TypographyExtensionTest.php
+++ b/tests/TypographyExtensionTest.php
@@ -135,6 +135,22 @@ final class TypographyExtensionTest extends TestCase
     }
 
     #[Test]
+    public function null_input_returns_empty_string_without_type_error(): void
+    {
+        $extension = new TypographyExtension();
+
+        // Optional ACF fields (link.title on an empty link, repeater rows the editor
+        // left blank, …) routinely pipe `null` into `|typography` from templates that
+        // don't guard with `{% if value %}`. Pre-1.2 the filter coerced null → '' for
+        // free; the strict-typed 1.2 signature broke that on PHP 8 with a TypeError
+        // that surfaces as a 500 on the live site. Accepting null and short-circuiting
+        // to '' mirrors how built-in Twig filters (`|trim`, `|lower`, `|escape`) behave.
+        $result = $extension->applyTypography(null);
+
+        self::assertSame('', $result);
+    }
+
+    #[Test]
     public function stringable_input_is_accepted_without_type_error(): void
     {
         $extension = new TypographyExtension([


### PR DESCRIPTION
## From-Project

Triggered while debugging a live-site 500 on **anyever** (branch `feature/timber-upgrade`). Symptom: the case-studies-slider component fataled in production after the `parisek/timber-kit` upgrade pulled in `parisek/twig-typography` 1.2.0:

```
Uncaught TypeError: Parisek\Twig\TypographyExtension::applyTypography():
Argument #1 ($string) must be of type Stringable|string, null given,
called in /wp-content/cache/timber/e8/e81b...php on line 99
```

Stack: `index.php → Timber\Post->content() → do_blocks() → BlockRenderer::render() → Timber::compile() → case-studies-slider.twig:36`.

Offending call: `{{ content.button.title|typography }}` against an empty optional ACF link field — `content.button.title` was `null`. Same shape exists across many other component templates that don't pre-guard with `{% if %}`.

## Why

The 1.2.0 modernization (#2) tightened `applyTypography()` to `string|\Stringable`. Pre-1.2 PHP silently coerced `null → ''`, so unguarded `null|typography` calls worked. Under PHP 8 strict types the same call now fatals — and surfaces as a hard 500 on the live site.

This is a **latent breakage**: it doesn't show up until a page actually renders a component with a null/optional value pumped through `|typography`. Auditing every callsite across ~100 downstream projects is impractical; backports of the strict signature would mean dozens of post-upgrade incidents.

## What

Widen `applyTypography()`'s first parameter to `string|\Stringable|null` and short-circuit to `''` when `null`. Keeps strict typing against arrays / objects / scalars so genuine bugs (`{{ items|typography }}`) still surface loudly.

```diff
- public function applyTypography(string|\Stringable $string, array $arguments = [], bool $use_defaults = true): string
+ public function applyTypography(string|\Stringable|null $string, array $arguments = [], bool $use_defaults = true): string
  {
+     if ($string === null) {
+         return '';
+     }
+
      $string = (string) $string;
      // …
```

Mirrors the null-tolerance convention of built-in Twig filters (`|trim`, `|lower`, `|escape`) — `null|filter` returning `''` is what template authors expect.

Added a regression test (`null_input_returns_empty_string_without_type_error`) documenting the contract.

## Test plan

- [x] `vendor/bin/phpunit` — 10/10 pass, including the new null-input test
- [x] `vendor/bin/phpstan analyse` — clean
- [ ] Manually verify the anyever case-studies-slider page renders without 500 after `composer update parisek/twig-typography` on `feature/timber-upgrade`

## Doctrine impact

One-off BC restore. The widening is **backwards-compatible**: no existing caller is broken (they were passing string/Stringable; the new signature accepts a strict superset). No downstream sync needed beyond `composer update`.

Tag suggestion: 1.2.1 (patch — backwards-compatible bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)